### PR TITLE
Build mpi and nompi versions in one recipe

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,9 +14,17 @@ if [[ $(uname) == Darwin ]]; then
     plutil -replace DTSDKName -string macosx${MACOSX_DEPLOYMENT_TARGET}internal $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
 fi
 
+if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
+    # We don't actually compile parallel MPB here (--enable-parallel) because
+    # the Python MPB interface in Pymeep isn't compatible with parallel MPB.
+    # However, since the parallel Python interface uses parallel HDF5, we
+    # need to build MPB against parallel HDF5, which just requires the MPI
+    # compiler wrappers.
+    export CC=mpicc
+    export CXX=mpicxx
+fi
+
 sh autogen.sh                \
-    CC=mpicc                 \
-    CXX=mpicxx               \
     --prefix=$PREFIX         \
     --enable-shared          \
     --with-libctl=no         \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+mpi:
+    - nompi
+    - mpich
+
+pin_run_as_build:
+    mpich: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mpb" %}
 {% set version = "1.9.1.dev" %}
-{% set buildnumber = 0 %}
+{% set buildnumber = 1 %}
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
 {% if mpi == "nompi" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,37 @@
+{% set name = "mpb" %}
 {% set version = "1.9.1.dev" %}
 {% set buildnumber = 0 %}
+# recipe-lint fails if mpi is undefined
+{% set mpi = mpi or 'nompi' %}
+{% if mpi == "nompi" %}
+# prioritize nompi via build number
+{% set buildnumber = buildnumber + 100 %}
+{% endif %}
 
 package:
-  name: mpb
+  name: {{ name }}
   version: {{version}}
 
 source:
-  git_url: https://github.com/NanoComp/mpb.git
+  git_url: https://github.com/NanoComp/{{ name }}.git
   git_rev: master
 
 build:
   number: {{buildnumber}}
+  {% if mpi != "nompi" %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% else %}
+  {% set mpi_prefix = "nompi" %}
+  {% endif %}
+  # add build string so packages can depend on
+  # mpi or nompi variants
+  # dependencies:
+  # `mpb * mpi_mpich_*` for mpich
+  # `mpb * mpi_*` for any mpi
+  # `mpb * nompi_*` for no mpi
+  string: "{{ mpi_prefix }}_nomklh{{ PKG_HASH }}_{{ buildnumber }}"
+  run_exports:
+    - {{ name }} * {{ mpi_prefix }}_*
   features:
     - nomkl
 
@@ -20,15 +41,17 @@ requirements:
     - {{ compiler('fortran') }}  # [linux]
     - gfortran_osx-64 4.*  # [osx]
   host:
-    - openblas
-    - mpich
+    - {{ mpi }}  # [mpi != 'nompi']
+    - libblas
+    - libcblas
+    - liblapack
     - fftw
-    - hdf5 * mpi_mpich_*
+    - hdf5 * {{ mpi_prefix }}_*
     - libctl >=4.1.4
   run:
-    - openblas
+    - {{ mpi }}  # [mpi != 'nompi']
+    - hdf5 * {{ mpi_prefix }}_*
     - fftw
-    - hdf5 * mpi_mpich_*
     - libctl >=4.1.4
     - nomkl
 


### PR DESCRIPTION
We were previously using an MPB built with `mpicc` for serial and parallel meep. This aligns the nightly build better with what is done in the conda-forge MPB recipe. 