### PR TITLE
Specify the version for the fortran compilers

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
+set -o xtrace
+
 export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
 
 # We need to install a later MacOS SDK than the default Travis SDK for compatibilty with the Anaconda compilers.
 if [[ $(uname) == Darwin ]]; then
     export MACOSX_DEPLOYMENT_TARGET="10.9"
-    export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
-    echo "Downloading ${MACOSX_DEPLOYMENT_TARGET} sdk"
-    curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz
-    tar -xf MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz -C "$(dirname "$CONDA_BUILD_SYSROOT")"
-    # set minimum sdk version to our target
-    plutil -replace MinimumSDKVersion -string ${MACOSX_DEPLOYMENT_TARGET} $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
-    plutil -replace DTSDKName -string macosx${MACOSX_DEPLOYMENT_TARGET}internal $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
+    if [[ "$HOME" == "/Users/travis" ]]; then
+        export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
+        echo "Downloading ${MACOSX_DEPLOYMENT_TARGET} sdk"
+        curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz
+        tar -xf MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz -C "$(dirname "$CONDA_BUILD_SYSROOT")"
+        # set minimum sdk version to our target
+        plutil -replace MinimumSDKVersion -string ${MACOSX_DEPLOYMENT_TARGET} $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
+        plutil -replace DTSDKName -string macosx${MACOSX_DEPLOYMENT_TARGET}internal $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
+    fi
 fi
 
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,9 @@
+fortran_compiler:
+    - gfortran
+fortran_compiler_version:
+    - '7.5'  # [osx]
+    - '7'  # [linux]
+
 mpi:
     - nompi
     - mpich

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,11 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
+    - autoconf
+    - automake
+    - m4
+    - libtool
+    - make
 
   host:
     - {{ mpi }}  # [mpi != 'nompi']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,13 +47,13 @@ requirements:
     - liblapack
     - fftw * {{ mpi_prefix }}_*
     - hdf5 1.10.5 {{ mpi_prefix }}_*
-    - libctl
+    - libctl >=4.5
 
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - fftw * {{ mpi_prefix }}_*
     - hdf5 1.10.5 {{ mpi_prefix }}_*
-    - libctl
+    - libctl >=4.5
     - nomkl
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,13 +52,11 @@ requirements:
     - liblapack
     - fftw * {{ mpi_prefix }}_*
     - hdf5 1.10.5 {{ mpi_prefix }}_*
-    - libctl >=4.5
 
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - fftw * {{ mpi_prefix }}_*
     - hdf5 1.10.5 {{ mpi_prefix }}_*
-    - libctl >=4.5
     - nomkl
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,19 +39,21 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
+
   host:
     - {{ mpi }}  # [mpi != 'nompi']
     - libblas
     - libcblas
     - liblapack
-    - fftw
+    - fftw * {{ mpi_prefix }}_*
     - hdf5 1.10.5 {{ mpi_prefix }}_*
-    - libctl >=4.4.0
+    - libctl
+
   run:
     - {{ mpi }}  # [mpi != 'nompi']
-    - hdf5 * {{ mpi_prefix }}_*
-    - fftw
-    - libctl >=4.4.0
+    - fftw * {{ mpi_prefix }}_*
+    - hdf5 1.10.5 {{ mpi_prefix }}_*
+    - libctl
     - nomkl
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mpb" %}
 {% set version = "1.10.1.dev" %}
-{% set buildnumber = 5 %}
+{% set buildnumber = 6 %}
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
 {% if mpi == "nompi" %}
@@ -17,7 +17,7 @@ source:
   git_rev: master
 
 build:
-  number: {{buildnumber}}
+  number: {{ buildnumber }}
   {% if mpi != "nompi" %}
   {% set mpi_prefix = "mpi_" + mpi %}
   {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ test:
 
 about:
   home: http:/github.com/NanoComp/mpb
-  license: GPL-2.0
+  license: GPL-2.0-or-later
   license_file: COPYING
   summary: MIT Photonic-Bands - computation of photonic band structures in periodic media
   doc_url: http://mpb.readthedocs.io


### PR DESCRIPTION
This avoids unsatisfiable dependency conflicts. The underlying issue seems to be that the newer default fortran compiler pulls in `libgfortran=5`, but at least a few of our dependencies require `libgfortran=4`.

This PR also includes a few other minor tweaks and some cleanup.